### PR TITLE
Fix, path dile-tabs.js no existe , se corrige al script correcto

### DIFF
--- a/docs/components/dile-tabs.md
+++ b/docs/components/dile-tabs.md
@@ -23,7 +23,7 @@ Import the component.
 
 ```javascript
 <script type="module">
-  import '@dile/ui/components/tabs/dile-tabs.js';
+  import '@dile/ui/components/tabs/tabs.js';
 </script>
 ```
 


### PR DESCRIPTION
Se corrige la documentación para el componente tabs. 
Con la ruta que proporciona la documentación se obtenía el siguiente error. 
![image](https://github.com/user-attachments/assets/6da6cd08-9049-4bc9-b0a5-cf05afdf9543)
Con la corrección, funciona correctamente
